### PR TITLE
Improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,70 @@
-![Build status](https://travis-ci.com/irinaespejo/workflow-madminer.svg?branch=master)
+![Build status][travis-build-status]
 
-# Madminer deployment using REANA, yadage and docker containerization
+# Madminer deployment with REANA, Yadage and Docker
 
 ## About
-This repository intends to create a full deployment of [MadMiner](https://github.com/johannbrehmer/madminer) (by Johann Brehmer, Felix Kling, and Kyle Cranmer) that parallelizes its bottlenecks, is reproducible and it facilitates the use of the tool in the community. 
-To achieve this we have generated a workflow using [yadage](https://github.com/yadage/yadage)
-(by Lukas Heinrich) and a containerization of the software dependencies in several docker images. The pipeline can be run with [REANA](http://www.reanahub.io/) a data analysis platform
+This repository intends to create a full deployment of [MadMiner][madminer-repo]
+(by Johann Brehmer, Felix Kling, and Kyle Cranmer) that parallelizes its bottlenecks, is reproducible 
+and facilitates the use of the tool in the community.
 
-This repo includes the workflow for the physics processing (config, generation of events with MadGraph, Delphes) and the machine learning processing (configuration, sampling, training) in a modular way. This means that each of this parts has its own workflow setup so that the user can mix-match. For instance, once the physics processes are run, one can play with different hyperparameters or samplings in the machine learning part without having to re-run MadGraph again.
+To achieve this we have generated a workflow using [yadage][yadage-repo] (by Lukas Heinrich)
+and a containerization of the software dependencies in several docker images.
+The pipeline can be run with [REANA][reana-webpage], a data analysis platform.
 
-Please, refer to the links for more information and tutorials about [MadMiner](https://madminer.readthedocs.io/en/latest/index.html) [tutorial](https://github.com/diana-hep/madminer/tree/master/examples/tutorial_particle_physics) and [yadage](https://yadage.readthedocs.io/en/latest/) [tutorial](https://yadage.github.io/tutorial/)
+This repo includes the workflow for the physics processing (config, generation of events with MadGraph, Delphes)
+and the machine learning processing (configuration, sampling, training) in a modular way.
+This means that each of this parts has its own workflow setup so that the user can mix-match.
+For instance, once the physics processes are run, one can play with different hyperparameters
+or samplings in the machine learning part, without having to re-run MadGraph again.
+
+Please, refer to the links for more information and tutorials about
+[MadMiner][madminer-docs] ([tutorial][madminer-tutorial]) and
+[yadage][yadage-docs] ([tutorial][yadage-tutorial])
 
 
 ## Docker images
-MadMiner is a set of complex tools with many steps and for that reason we considered better to split the software dependencies and the code for the workflow in two docker images plus another one containing the latest MadMiner library version. All of the official images are hosted in the [madminertool](https://hub.docker.com/u/madminertool) DockerHub.
+MadMiner is a set of complex tools with many steps. For that reason, we considered better to split
+the software dependencies and workflow code in two Docker images,
+plus another one containing the latest MadMiner library version. 
+All of the official images are hosted in the [madminertool][madminer-dockerhub] DockerHub.
 
-- [madminertool/docker-madminer](https://hub.docker.com/r/madminertool/docker-madminer)
-Contains only latest version of MadMiner
-- [madminertool/docker-madminer-phyics](https://hub.docker.com/r/madminertool/docker-madminer-physics)
-Contains the code necessary to configure, generate and process events according to MadMiner. You will also find the software dependencies in the directory `/home/software`. Dockerfile [here](https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-physics/Dockerfile)
-- [madminertool/docker-madminer-ml](https://hub.docker.com/r/madminertool/docker-madminer-ml)
-Contains the code necessary to configure, train and evaluate in the MadMiner framework. Dockerfile [here](https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-ml/Dockerfile)
+- [madminertool/docker-madminer][madminer-raw-docker-image]:
+contains only latest version of MadMiner.
+- [madminertool/docker-madminer-physics][madminer-ph-docker-image]:
+contains the code necessary to configure, generate and process events according to MadMiner.
+You will also find the software dependencies in the directory `/home/software`. [Dockerfile][madminer-ph-docker-file].
+- [madminertool/docker-madminer-ml][madminer-ml-docker-image]:
+contains the code necessary to configure, train and evaluate in the MadMiner framework. [Dockerfile][madminer-ml-docker-file].
 
-To pull any of the images and see its content
-
+To pull any of the images and see its content:
 ```bash
-$ docker pull madminertool/<image-name>
-$ docker run -it madminertool/<image-name> bash
+docker pull madminertool/<image-name>
+docker run -it madminertool/<image-name> bash
 <container-id>#/home $ ls
 ```
+
 If you want to check the Dockerfile for the last two images go to `worklow-madminer/docker`.
 
-*The point of this repository is to make the life easy for the user so you won't need to figure out yourself the arguments of the scripts on `/home/code/` nor how to input new observables. The whole pipeline will be automatically generated when you follow the steps in the sections below. Also you will have the chance to input your own parameters, observables, cuts etc. without even needing to pull yourself  the docker images.*
+_The point of this repository is to make the life easier for the users so they won't need
+to figure out themselves the arguments of the scripts on `/home/code/` nor how to input new observables.
+The whole pipeline will be automatically generated when they follow the steps in the sections below.
+Also they will have the chance to input their own parameters, observables, cuts etc.
+without even needing to pull the Docker images._
 
-## Install the dependencies and run the workflows
-Installing the dependiencies depends on how you want to run the workflow: locally using yadage alone or in a REANA cluster.
+
+## Dependencies and workflows
+Dependency installation depends on how you want to run the workflow: using a REANA cluster, or locally using yadage.
 
 
-	
-### deploy with REANA
-
-To deploy Madminer locally using [REANA](http://www.reana.io/)  use Minikube as emulator for a cluster. Please refer to https://reana-cluster.readthedocs.io/en/latest/gettingstarted.html  for more details. 
-If you have access to a REANA cluster, then you will only need to introduce the credentials as below.
-To generate the following workflow 
+### Deploy with REANA
+To deploy Madminer locally using [REANA][reana-webpage], use _Minikube_ as emulator for a cluster.
+Please refer to the [REANA-Cluster documentation][reana-cluster-docs] for more details.
+If you have access to a REANA cluster, then you will only need to introduce the credentials as shown below,
+to generate the following combined-workflow:
 
 ![image of the workflow](images/yadage_workflow_instance_full.png)
 
-move to the directory `example-full/` and run
+To introduce the credentials, go to the `example-full/` directory and run:
 ```bash
 $ virtualenv ~/.virtualenvs/myreana
 $ source ~/.virtualenvs/myreana/bin/activate
@@ -65,105 +83,147 @@ $ source ~/.virtualenvs/myreana/bin/activate
 (myreana) $ reana-client start
 (myreana) $ reana-client status
 ```
-it might take some time to finish depending on the job and the cluster, once it does list and download  the files
+
+It might take some time to finish depending on the job and the cluster. Once it does, list and download the files:
 ```bash
 (myreana) $ reana-client ls
 (myreana) $ reana-client download <path/to/file/on/reana/workon>
 ```
-the command `reana-client ls` will display that there is one folder containing the results from each step. You can download any intermediate result you are interested in for example `combine/combined_delphes.h5`, `evaluating_0/
-Results.tar.gz` or all the plots available in `plotting/`.
+
+The command `reana-client ls` will display the folders containing the results from each step.
+You can download any intermediate result you are interested in (for example `combine/combined_delphes.h5`,
+`evaluating_0/Results.tar.gz` or all the plots available in `plotting/`).
 
 
-### deploy locally with yadage
-
-Install yadage and the dependencies to visualize workflows [viz]
+### Deploy with Yadage (locally)
+Install Yadage and its dependencies to visualize workflows:
 ```bash
-  pip install yadage[viz]
+pip install yadage[viz]
 ```
-Also, you need the graphviz package
-Check it was succesful by running:
+
+Also, you would need the `graphviz` package. Check it was successfully installed by running:
 ```bash
-  yadage-run -t from-github/testing/local-helloworld workdir workflow.yml -p par=World
+yadage-run -t from-github/testing/local-helloworld workdir workflow.yml -p par=World
 ```
-It should output lines similar to this one `2019-01-11 09:51:51,601 |         yadage.utils |   INFO | setting up backend multiproc:auto with opts {}` and no errors. Refer to the yadage links above for more details.
 
+It should see a log entry like the following. Refer to the Yadage links above for more details:
+```
+2019-01-11 09:51:51,601 | yadage.utils | INFO | setting up backend multiproc:auto with opts {}
+```
 
-For the first run we recommend using our default files `input.yml`. Also, decreasing `njobs` and `ntrainsamples` will be faster.
+For the first run, we recommend using our default `input.yml` files, decreasing both `njobs` and `ntrainsamples` for speed.
 
-
-move to the directory of the example and run 
+Finally, move to the directory of the example and run:
 ```bash
-  sudo rm -rf workdir  && yadage-run   workdir workflow.yml  -p inputfile='"inputs/input.yml"'  -p njobs="6"  -p ntrainsamples="2"  -d initdir=$PWD --visualize
+sudo rm -rf workdir && yadage-run workdir workflow.yml \
+    -p inputfile='"inputs/input.yml"' \
+    -p njobs="6" \
+    -p ntrainsamples="2" \
+    -d initdir=$PWD \
+    --visualize
 ```
-to run again the command you must first remove workdir `rm -rf workdir/`
->what is every element in the command?
-	- `workdir` is creating a new dir where all the intermediate and output files will be saved.
-	- `workflow.yml` is the file that connects the different stages of the workflow, it must be placed in the working directory
-	- all the parameters are preceed by `-p`: `njobs` is the number of maps in the physics workflow, `ntrainsamples` is the same as `njobs` but to scale the traning sample process, `inputfile` has a configuration of all the parameters and options.
-	- `-d initdir=$PWD` initializes the workflow in the present directory
-	- `--visualize` generates an image of the workflow
 
+To run again the command you must first remove the `workdir` folder:
+```bash
+rm -rf workdir/
+```
 
-### running only one part of the workflow
-The image of the workflow above shows how 2 workflows are united
+**What is every element in the command?**
+- `workdir`: specifies the new directory where all the intermediate and output files will be saved.
+- `workflow.yml`: file connecting the different stages of the workflow. It must be placed in the working directory.
+- `-p <param>`: all the parameters. In this case:
+    - `inputfile` has a configuration of all the parameters and options.
+    - `njobs`: number of maps in the Physics workflow.
+    - `ntrainsamples` number to scale the training sample process.
+- `-d initdir`: specifies the directory where the the workflow is initiated.
+- `--visualize`: specifies the creation of a workflow image.
+
 
 ## Analysis structure
+
 ### 1. Analysis code
-#### Physics part
-configurate.py - Put together inputs and initialize
-	- Initializes MadMiner, add parameters, add benchmarks, set benchmarks from morphing and save.
-	`python code/configurate.py` 
+In the Physics case:
 
-generate.py - Generate events scripts
-	- Prepare scripts for MadGraph for background and signal events based on previous optimization.
-	`python code/generate.py {njobs} {h5_file}` where `{njobs}` is the initial parameter  `njobs` and `{h5_file}` is a file generated in configurate.py with the MadMiner configuration.
+- `configurate.py`: initializes MadMiner, add parameters, add benchmarks and set morphing benchmarks.
 
-delphes.py - Run Delphes
-	- Pass the events through Delphes, add observables and cuts, save.
-	 `python code/delphes.py {h5_file} {event_file} {input_file}` where  `{h5_file}` is the same file as above  `{event_file}` is the file  `tag_1_pythia8_events.hepmc.gz` and `{input_file}{input_file}` is the initial `input_delphes.yml`
+    ```bash
+    python code/configurate.py
+    ```
 
-#### ML part
+- `generate.py`: prepares MadGraph scripts for background and signal events based on previous optimization. Run it with:
+    - `{njobs}` as the initial parameter `njobs`.
+    - `{h5_file}` as the MadMiner configuration file (from the previous `configurate.py` execution).
 
-### 2. Anaylsis workflow
-Without taking into account the inputs ans the map-reduce the general strcture of the workflow is the following
+    ```bash
+    python code/generate.py {njobs} {h5_file}
+    ```
 
-				+--------------+
-				|  Configurate |
-				+--------------+
-					   |
-					   |
-					   v
-				+--------------+
-				|   Generate   |
-				+--------------+
-	   				   |
-					   |
-					   v
-				+--------------+
-				|   MG+Pythia  |
-				+--------------+
-					   |
-					   |
-					   v
-				+--------------+
-				|   Delphes    |
-				+--------------+
-					   |
-					   |
-					   v
-				+-----------------+
-				|   Sampling      |
-				+-----------------+
-				           |
-					   |
-					   v
-                                +-----------------+
-				|   Training      |
-				+-----------------+
-				           |
-					   |
-					   v
-                                +-----------------+
-				|    Testing      |
-				+-----------------+
+- `delphes.py`: runs Delphes by passing the inputs, adding observables, adding cuts and saving. Run it with:
+    - `{h5_file}` as the MadMiner configuration file.
+    - `{event_file}` as `tag_1_pythia8_events.hepmc.gz`.
+    - `{input_file}` as the initial `input_delphes.yml` file.
 
+    ```bash
+    python code/delphes.py {h5_file} {event_file} {input_file}
+    ```
+
+### 2. Analysis workflow
+Without taking into account the inputs and the map-reduce, the general workflow structure is the following:
+
+                +--------------+
+                |  Configurate |
+                +--------------+
+                        |
+                        |
+                        v
+                +--------------+
+                |   Generate   |
+                +--------------+
+                        |
+                        |
+                        v
+                +--------------+
+                |   MG+Pythia  |
+                +--------------+
+                        |
+                        |
+                        v
+                +--------------+
+                |   Delphes    |
+                +--------------+
+                        |
+                        |
+                        v
+                +--------------+
+                |   Sampling   |
+                +--------------+
+                        |
+                        |
+                        v
+                +--------------+
+                |   Training   |
+                +--------------+
+                        |
+                        |
+                        v
+                +--------------+
+                |    Testing   |
+                +--------------+
+
+
+[madminer-ph-docker-file]: https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-physics/Dockerfile
+[madminer-ph-docker-image]: https://hub.docker.com/r/madminertool/docker-madminer-physics
+[madminer-ml-docker-file]: https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-ml/Dockerfile
+[madminer-ml-docker-image]: https://hub.docker.com/r/madminertool/docker-madminer-ml
+[madminer-raw-docker-image]: https://hub.docker.com/r/madminertool/docker-madminer
+
+[madminer-dockerhub]: https://hub.docker.com/u/madminertool
+[madminer-docs]: https://madminer.readthedocs.io/en/latest/index.html
+[madminer-repo]: https://github.com/diana-hep/madminer
+[madminer-tutorial]: https://github.com/diana-hep/madminer/tree/master/examples/tutorial_particle_physics
+[reana-cluster-docs]: https://reana-cluster.readthedocs.io/en/latest/gettingstarted.html
+[reana-webpage]: http://www.reanahub.io/
+[travis-build-status]: https://travis-ci.com/irinaespejo/workflow-madminer.svg?branch=master
+[yadage-docs]: https://yadage.readthedocs.io/en/latest/
+[yadage-repo]: https://github.com/yadage/yadage
+[yadage-tutorial]: https://yadage.github.io/tutorial/


### PR DESCRIPTION
After briefly reading through the repository documentation, I think there is room for improvement, in addition to typo fixes.

This PR has reformat the `README` file:
- Wrapping lines at width equals 120.
- Move link definitions to the bottom.
- Reformat long code snippets ([those requiring horizontal scroll](https://github.com/scailfin/workflow-madminer/compare/master...Sinclert:format-readme?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8L96)).
- Reformat lists of arguments (using the `-` key).
- Fix [`Analysis workflow` diagram boxes](https://github.com/scailfin/workflow-madminer#2-anaylsis-workflow).
- Remove [incomplete `ML part` header](https://github.com/scailfin/workflow-madminer#ml-part).