### PR TITLE
Fix Physics workflow steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ docker-images/docker-madminer-all/requirements-*.txt
 
 # Ignore any analysis step output folders
 **/data
+**/extract
 **/logs
 **/mg_processes
 

--- a/docker-images/docker-madminer-physics/Dockerfile
+++ b/docker-images/docker-madminer-physics/Dockerfile
@@ -30,6 +30,7 @@ RUN curl -sSL "https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/${MG_VERSION}
 ENV ROOTSYS /usr/local
 ENV PATH $PATH:$ROOTSYS/bin
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$ROOTSYS/lib
+ENV DYLD_LIBRARY_PATH $DYLD_LIBRARY_PATH:$ROOTSYS/lib
 
 RUN echo "install lhapdf6" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
 RUN echo "install pythia8" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
@@ -43,6 +44,7 @@ WORKDIR ${PROJECT_FOLDER}
 #### Copy files
 COPY code ./code
 COPY scripts ./scripts
+COPY requirements.txt .
 
 
 # Install Python2 dependencies

--- a/docker-images/docker-madminer-physics/code/cards/pythia8_card.dat
+++ b/docker-images/docker-madminer-physics/code/cards/pythia8_card.dat
@@ -26,7 +26,10 @@ Main:numberOfEvents      = -1
 ! -------------------------------------------------------------------
 !
 HEPMCoutput:file         = auto
-HEPMCoutput:useWeightIDs = on
+!
+! This option causes Pythia8 to start populating logs with an error message
+! until the disk is full and crashes. DO NOT UNCOMMENT
+! HEPMCoutput:useWeightIDs = on
 !
 ! --------------------------------------------------------------------
 ! Parameters relevant only when performing MLM merging, which can be

--- a/docker-images/docker-madminer-physics/code/combine.py
+++ b/docker-images/docker-madminer-physics/code/combine.py
@@ -5,10 +5,20 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import numpy as np
 import sys
-import h5py
-import shutil
+
+from madminer import combine_and_shuffle
+from pathlib import Path
+
+
+##########################
+#### Global variables ####
+##########################
+
+project_dir = Path(__file__).parent.parent
+
+data_dir = project_dir.joinpath('data')
+file_path = data_dir.joinpath("combined_delphes.h5")
 
 
 ##########################
@@ -25,24 +35,14 @@ h5_list = sys.argv[1]
 h5_list = h5_list.replace('[', '')
 h5_list = h5_list.replace(']', '')
 h5_list = h5_list.split()
-h5_list = [str(file[1:]) for file in h5_list]
-
-print(f"Cleaning... {h5_list}")
+h5_list = [str(file) for file in h5_list]
 
 
 ##########################
 #### Merging entities ####
 ##########################
 
-FINAL_NAME = "combined_delphes.h5"
-MERGE_ON = ["samples/observations", "samples/weights"]
-
-shutil.copy(h5_list[0], FINAL_NAME)
-target_file = h5py.File(FINAL_NAME, 'r+')
-
-for merge_name in MERGE_ON:
-	data_list = [np.array(h5py.File(name, 'r')[merge_name]) for name in h5_list]
-	merged_data = np.concatenate(data_list, axis=0)
-
-	del target_file[merge_name]
-	target_file.create_dataset(merge_name, data=merged_data)
+combine_and_shuffle(
+	input_filenames=h5_list,
+	output_filename=file_path,
+)

--- a/docker-images/docker-madminer-physics/scripts/3_pythia.sh
+++ b/docker-images/docker-madminer-physics/scripts/3_pythia.sh
@@ -49,7 +49,7 @@ sh "${SIGNAL_ABS_PATH}/madminer/scripts/run"*".sh" "${MADGRAPH_ABS_PATH}" "${SIG
 
 tar -czvf "${SIGNAL_ABS_PATH}/Events/Events.tar.gz" \
     -C "${SIGNAL_ABS_PATH}" \
-    "Events/"*"/"* \
-    "madminer/cards/benchmark_"*".dat"
+    "Events" \
+    "madminer/cards"
 
 # cp /madminer/code/mg_processes/signal/Events/Events.tar.gz {mgworkdir}

--- a/docker-images/docker-madminer-physics/scripts/4_delphes.sh
+++ b/docker-images/docker-madminer-physics/scripts/4_delphes.sh
@@ -45,7 +45,7 @@ mv "${EXTRACT_PATH}/madminer/cards/benchmark_"*".dat" "${EXTRACT_PATH}/madminer/
 mkdir -p "${DATA_PATH}"
 python3 "${PROJECT_PATH}/code/delphes.py" \
     "${CONFIG_FILE}" \
-    "${EXTRACT_PATH}/Events" \
+    "${EXTRACT_PATH}/Events/run_01" \
     "${INPUT_FILE}" \
     "${EXTRACT_PATH}/madminer/cards/benchmark.dat"
 


### PR DESCRIPTION
This PR makes the whole _Physics_ workflow locally testable.

Last PR (https://github.com/scailfin/workflow-madminer/pull/14) stablished a solid foundation to move the shell commands from the [steps.yml](https://github.com/scailfin/workflow-madminer/blob/master/reana/workflows/yadage/steps.yml) file to proper `.sh` files (more easily runnable), but the whole _Physics_ workflow hadn't been completely run due to a [Pythia8](http://home.thep.lu.se/~torbjorn/Pythia.html) never ending step.

Turns out the Pythia8 step is not that computationally expensive. The long delays were due to a misconfiguration on the [pythia8_card.dat](https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-physics/code/cards/pythia8_card.dat#L29), were the option `useWeightIDs` was activated, making Pythia to loop infinitely. This option was, at some point, disabled on the real MadMiner repository (check [this commit](https://github.com/diana-hep/madminer/commit/6bddeaacb342f6cf72b9e128314790749a7ab456)), but never on the workflow version (this repo).

---

Additionally, this PR performs includes:
- Small fixes on the [3_pythia.sh](https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-physics/scripts/3_pythia.sh) and [4_delphes.sh](https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-physics/scripts/4_delphes.sh) scripts.
- Simplification of the [combine.py](https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-physics/code/combine.py) file, as the `combine_and_shuffle` function is natively offered by MadMiner.