### PR TITLE
Fix Delphes non-'sm' execution

### DIFF
--- a/docker-images/docker-madminer-physics/Dockerfile
+++ b/docker-images/docker-madminer-physics/Dockerfile
@@ -27,6 +27,7 @@ ENV MG_FOLDER "MG5_aMC_v2_6_7"
 ENV MG_BINARY "MG5_aMC_v2_6_7/bin/mg5_aMC"
 RUN curl -sSL "https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/${MG_VERSION}.tar.gz" | tar -xzv
 
+# ROOT environment variables
 ENV ROOTSYS /usr/local
 ENV PATH $PATH:$ROOTSYS/bin
 ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$ROOTSYS/lib
@@ -36,6 +37,9 @@ RUN echo "install lhapdf6" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
 RUN echo "install pythia8" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
 RUN echo "install pythia-pgs" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
 RUN echo "install Delphes" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
+
+# Delphes environment variables
+ENV ROOT_INCLUDE_PATH $ROOT_INCLUDE_PATH:${SOFTWARE_FOLDER}/${MG_FOLDER}/Delphes/external
 
 
 #### Set working directory

--- a/docker-images/docker-madminer-physics/Makefile
+++ b/docker-images/docker-madminer-physics/Makefile
@@ -9,6 +9,7 @@ all: clean build push
 .PHONY: clean
 clean:
 	@rm -rf data
+	@rm -rf extract
 	@rm -rf code/logs
 	@rm -rf code/mg_processes
 	@find . -name "folder_*.tar.gz" -delete

--- a/docker-images/docker-madminer-physics/code/delphes.py
+++ b/docker-images/docker-madminer-physics/code/delphes.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
+import re
 import sys
 import yaml
 from madminer import DelphesReader
@@ -47,13 +48,28 @@ with open(benchmark_file, 'r') as f:
 reader = DelphesReader(config_file)
 
 
+##########################
+#### Find events file ####
+##########################
+
+events_file = None
+events_regex = re.compile(r'tag_[0-9]+_pythia8_events\.hepmc\.gz')
+
+# This is required when running locally
+for _, _, files in os.walk(event_path):
+    for file in files:
+        if events_regex.match(file):
+            events_file = file
+            break
+
+
 #########################
 ###### Run Delphes ######
 #########################
 
 reader.add_sample(
-    lhe_filename=event_path + '/unweighted_events.lhe.gz',
-    hepmc_filename=event_path + '/tag_1_pythia8_events.hepmc.gz',
+    lhe_filename=event_path + '/' + 'unweighted_events.lhe.gz',
+    hepmc_filename=event_path + '/' + events_file,
     sampled_from_benchmark=benchmark,
     weights='lhe',
 )

--- a/docker-images/docker-madminer-physics/code/delphes.py
+++ b/docker-images/docker-madminer-physics/code/delphes.py
@@ -54,7 +54,7 @@ reader = DelphesReader(config_file)
 reader.add_sample(
     lhe_filename=event_path + '/unweighted_events.lhe.gz',
     hepmc_filename=event_path + '/tag_1_pythia8_events.hepmc.gz',
-    sampled_from_benchmark=benchmark,  # 'sm'
+    sampled_from_benchmark=benchmark,
     weights='lhe',
 )
 

--- a/docker-images/docker-madminer-physics/code/generate.py
+++ b/docker-images/docker-madminer-physics/code/generate.py
@@ -102,6 +102,6 @@ madminer_run_wrapper(sample_benchmarks=sample_list, run_type='signal')
 ### Run with background ###
 ###########################
 
-sample_list = ['sm' for i in range(num_jobs)]
-
-madminer_run_wrapper(sample_benchmarks=sample_list, run_type='background')
+# Currently not used
+# sample_list = ['sm' for i in range(num_jobs)]
+# madminer_run_wrapper(sample_benchmarks=sample_list, run_type='background')

--- a/docker-images/docker-madminer-physics/scripts/3_pythia.sh
+++ b/docker-images/docker-madminer-physics/scripts/3_pythia.sh
@@ -40,8 +40,17 @@ SIGNAL_ABS_PATH="${PROJECT_PATH}/${SIGNAL_FOLDER}"
 LOGS_ABS_PATH="${PROJECT_PATH}/${LOGS_FOLDER}"
 
 
+# Cleanup previous files (useful when run locally)
+rm -rf "${SIGNAL_ABS_PATH}/Events"
+rm -rf "${SIGNAL_ABS_PATH}/madminer"
+rm -rf "${SIGNAL_ABS_PATH}/rw_me"
+
+mkdir -p "${SIGNAL_ABS_PATH}/Events"
+mkdir -p "${SIGNAL_ABS_PATH}/madminer"
+mkdir -p "${SIGNAL_ABS_PATH}/rw_me"
+
+
 # Perform actions
-rm -rf "${SIGNAL_ABS_PATH}/madminer/"*
 tar -xvf "${ZIP_FILE}" -C "${SIGNAL_ABS_PATH}/madminer"
 
 mkdir -p "${LOGS_ABS_PATH}"

--- a/docker-images/docker-madminer-physics/scripts/4_delphes.sh
+++ b/docker-images/docker-madminer-physics/scripts/4_delphes.sh
@@ -37,8 +37,12 @@ EXTRACT_PATH="${PROJECT_PATH}/extract"
 DATA_PATH="${PROJECT_PATH}/data"
 
 
-# Perform actions
+# Cleanup previous files (useful when run locally)
+rm -rf "${EXTRACT_PATH}"
 mkdir -p "${EXTRACT_PATH}"
+
+
+# Perform actions
 tar -xvf "${EVENTS_FILE}" -C "${EXTRACT_PATH}"
 mv "${EXTRACT_PATH}/madminer/cards/benchmark_"*".dat" "${EXTRACT_PATH}/madminer/cards/benchmark.dat"
 


### PR DESCRIPTION
This PR aims to continue the fixes from previous PR (https://github.com/scailfin/workflow-madminer/pull/15), that allowed all the _Pyshics_ use-case steps to be run locally.

For now, the `ROOT_INCLUDE_PATH` Delphes **run-time used** environment variable has been added. When not defined, the beginning of the log file (`log_delphes.log`) that the 4th step of the Physics workflow creates, look like this:
```
Error in cling::AutoloadingVisitor::InsertIntoAutoloadingState:
   Missing FileEntry for ExRootAnalysis/ExRootTreeReader.h
   requested to autoload type ExRootTreeReader
Error in cling::AutoloadingVisitor::InsertIntoAutoloadingState:
   Missing FileEntry for ExRootAnalysis/ExRootTreeWriter.h
   requested to autoload type ExRootTreeWriter
Error in cling::AutoloadingVisitor::InsertIntoAutoloadingState:
   Missing FileEntry for ExRootAnalysis/ExRootTreeBranch.h
   requested to autoload type ExRootTreeBranch
Error in cling::AutoloadingVisitor::InsertIntoAutoloadingState:
   Missing FileEntry for ExRootAnalysis/ExRootResult.h
   requested to autoload type ExRootResult
Error in cling::AutoloadingVisitor::InsertIntoAutoloadingState:
   Missing FileEntry for ExRootAnalysis/ExRootClassifier.h
   requested to autoload type ExRootClassifier
Error in cling::AutoloadingVisitor::InsertIntoAutoloadingState:
   Missing FileEntry for ExRootAnalysis/ExRootFilter.h
   requested to autoload type ExRootFilter
Error in cling::AutoloadingVisitor::InsertIntoAutoloadingState:
   Missing FileEntry for ExRootAnalysis/ExRootProgressBar.h
   requested to autoload type ExRootProgressBar
Error in cling::AutoloadingVisitor::InsertIntoAutoloadingState:
   Missing FileEntry for ExRootAnalysis/ExRootConfReader.h
   requested to autoload type ExRootConfParam
Error in cling::AutoloadingVisitor::InsertIntoAutoloadingState:
   Missing FileEntry for ExRootAnalysis/ExRootConfReader.h
   requested to autoload type ExRootConfReader
Error in cling::AutoloadingVisitor::InsertIntoAutoloadingState:
   Missing FileEntry for ExRootAnalysis/ExRootTask.h
   requested to autoload type ExRootTask
** INFO: adding module        ParticlePropagator       ParticlePropagator       
** INFO: adding module        Efficiency               ChargedHadronTrackingEfficiency
... From this point forward modules are loaded normally ...
```

The reference to solve this problem has been obtaine from [this ROOT forum response](https://root-forum.cern.ch/t/delphes-madanalysis/27879/4).

---

### ~What is missing in this PR?~
~Last thing I would like to debug before merging, is the fact that the Physics 4th step (executable via the [4_delphes.sh](https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-physics/scripts/4_delphes.sh) script), only works when the provided benchmark is `sm`.~

---

### Additional changes
In order to make the [4_delphes.sh](https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-physics/scripts/4_delphes.sh) script work with any benchmark, the `/extract` folder need to be cleanup after each run. This is an issue when running all the benchmark-dependent Delphes steps locally, but not when running them on completely isolated environments (REANA).

Furthermore, I have implemented a [_"events file discovery snippet"_](https://github.com/scailfin/workflow-madminer/pull/16/files#diff-e8c5262d5171de8e0eeb3d5b2f4a97c6R51) to work with different named output files from the previous step (step 3: Pythia simulation).

I could not figure out why this is happening, so event files will look like:
- `tag_1_pythia8_events.hepmc.gz`
- `tag_2_pythia8_events.hepmc.gz`
- ...
