### PR TITLE
Define REANA workflow ML scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ docker-images/docker-madminer-all/requirements-*.txt
 **/extract
 **/logs
 **/mg_processes
+**/models
+**/plots
+**/rates
+**/results
+**/test
 
 # Ignore any analysis intermediate files
 **/*.tar.gz

--- a/docker-images/docker-madminer-ml/Dockerfile
+++ b/docker-images/docker-madminer-ml/Dockerfile
@@ -3,10 +3,13 @@
 FROM madminertool/docker-madminer:latest
 
 
-#### Set working directory and copy files
+#### Set working directory
 WORKDIR /madminer
-COPY requirements.txt .
+
+#### Copy files
 COPY code ./code
+COPY scripts ./scripts
+COPY requirements.txt .
 
 
 # Install Python2 dependencies

--- a/docker-images/docker-madminer-ml/Makefile
+++ b/docker-images/docker-madminer-ml/Makefile
@@ -3,7 +3,18 @@ REGISTRY=madminertool
 VERSION=$(shell cat ./VERSION)
 
 
-all: build push
+all: clean build push
+
+
+.PHONY: clean
+clean:
+	@rm -rf data
+	@rm -rf models
+	@rm -rf plots
+	@rm -rf rates
+	@rm -rf results
+	@rm -rf test
+	@find . -name "*.tar.gz" -delete
 
 
 .PHONY: build

--- a/docker-images/docker-madminer-ml/code/configurate_ml.py
+++ b/docker-images/docker-madminer-ml/code/configurate_ml.py
@@ -9,9 +9,8 @@ import h5py
 import logging
 import sys
 import yaml
-from pathlib import Path
 
-from madminer.sampling import combine_and_shuffle
+from pathlib import Path
 from madminer.sampling import SampleAugmenter
 
 # These methods are applied if specified in the input files
@@ -69,24 +68,19 @@ with open(inputs_file) as f:
 
 nuisance = inputs['include_nuisance_parameters']
 methods = inputs['methods']
-shuffle = inputs['shuffle']
 samples = int(inputs['n_samples']['train'])
 split = float(inputs['test_split'])
 
-with h5py.File(data_file, 'r') as f:
-    parameters = f['parameters']['names']
+# Do NOT use a context manager here, the file would be closed
+f = h5py.File(data_file, 'r')
+parameters = f['parameters']['names']
 
 
 #############################
 #### Instantiate Sampler ####
 #############################
 
-if shuffle:
-    data_file_shuffled = data_dir + '/' + 'combined_delphes_shuffled.h5'
-    combine_and_shuffle(input_filenames=[data_file], output_filename=data_file_shuffled)
-    sampler = SampleAugmenter(data_file_shuffled, include_nuisance_parameters=nuisance)
-else:
-    sampler = SampleAugmenter(data_file, include_nuisance_parameters=nuisance)
+sampler = SampleAugmenter(data_file, include_nuisance_parameters=nuisance)
 
 
 ##############################

--- a/docker-images/docker-madminer-ml/code/evaluation.py
+++ b/docker-images/docker-madminer-ml/code/evaluation.py
@@ -55,7 +55,7 @@ tests_dir = str(project_dir.joinpath('test'))
 sampling_methods = {
     'benchmark': benchmark,
     'benchmarks': benchmarks,
-    'morphing_points': morphing_point,
+    'morphing_point': morphing_point,
     'random_morphing_points': random_morphing_points,
 }
 
@@ -66,7 +66,7 @@ sampling_methods = {
 
 inputs_file = sys.argv[1]
 eval_folder = sys.argv[2]
-config_file = sys.argv[3]
+data_file = sys.argv[3]
 
 with open(inputs_file) as f:
     inputs = yaml.safe_load(f)
@@ -81,10 +81,11 @@ fisher_info = dict(inputs['fisher_information'])
 gen_method = str(os.path.split(os.path.abspath(eval_folder))[1])
 luminosity = float(inputs['luminosity'])
 test_split = float(inputs['test_split'])
-num_samples = int(inputs['n_samples']['train'])
+num_samples = int(inputs['n_samples']['test'])
 
-with h5py.File(config_file, 'r') as f:
-    parameters = f['parameters']['names']
+# Do NOT use a context manager here, the file would be closed
+f = h5py.File(data_file, 'r')
+parameters = f['parameters']['names']
 
 
 ###############################
@@ -119,7 +120,7 @@ def calc_num_events(config_file, lum):
         partition='train',
         test_split=test_split
     )
-    logging.info(f"SampleAugmenter xsecs: ", xs_xsecs[0])
+    logging.info(f"SampleAugmenter xsecs: {xs_xsecs[0]}")
 
     # Second: calculate expected number of events
     _, xs, _ = sample_augmenter.cross_sections(theta=morphing_point(theta_true))
@@ -164,15 +165,15 @@ def generate_test_data_ratio(method, params):
     :param params: list of parameter names the analysis is taking
     """
 
-    sampler = SampleAugmenter(config_file, include_nuisance_parameters=False)
-    thetas = inputs['evaluation'][method]
+    sampler = SampleAugmenter(data_file, include_nuisance_parameters=False)
+    thetas = inputs[method]
 
     if len(thetas) == 1:
         theta = thetas['theta']
         theta_sampling = theta['sampling_method']
 
         # Default arguments
-        theta_args = theta['argument']
+        theta_args = [theta['argument']]
 
         # Overriding default 'theta' arguments
         if theta_sampling == 'random_morphing_points':
@@ -195,15 +196,17 @@ def generate_test_data_ratio(method, params):
         theta_1_sampling = theta_1['sampling_method']
 
         # Default arguments
-        theta_0_args = [theta_0['argument']]
-        theta_1_args = [theta_1['argument']]
+        theta_0_args = []
+        theta_1_args = []
 
         # Overriding default 'theta' arguments
         if theta_0_sampling == 'random_morphing_points':
             theta_0_args = generate_theta_args(theta_0, parameters)
+            theta_1_args = [theta_1['argument']]
 
         # Overriding default 'theta' arguments
         if theta_1_sampling == 'random_morphing_points':
+            theta_0_args = [theta_0['argument']]
             theta_1_args = generate_theta_args(theta_1, parameters)
 
         # Getting the specified sampling method
@@ -215,7 +218,7 @@ def generate_test_data_ratio(method, params):
             theta1=theta_1_method(*theta_1_args),
             n_samples=num_samples,
             folder=tests_dir + f'/{method}/',
-            filename='test'
+            filename='test',
         )
 
 
@@ -226,7 +229,7 @@ def generate_test_data_score(method, params):
     :param params: list of parameter names the analysis is taking
     """
 
-    sampler = SampleAugmenter(config_file, include_nuisance_parameters=False)
+    sampler = SampleAugmenter(data_file, include_nuisance_parameters=False)
     thetas = inputs['evaluation'][method]
 
     theta = thetas['theta']
@@ -263,7 +266,7 @@ def save_limits(mode, method, models_path, include_xs):
     :param include_xs: flag indicating whether or not include the cross section
     """
 
-    _, p_values, best_fit_index = limits.expected_limits(
+    _, p_values, best_fit_index, _, _, _ = limits.expected_limits(
         mode=mode,
         theta_true=theta_true,
         grid_ranges=theta_ranges,
@@ -305,8 +308,8 @@ if asymptotic['bool']:
 
 
     # Computes rates and grid
-    limits = AsymptoticLimits(config_file)
-    theta_grid, p_values, best_fit_index = limits.expected_limits(
+    limits = AsymptoticLimits(data_file)
+    theta_grid, p_values, best_fit_index, _, _, _ = limits.expected_limits(
         mode="rate",
         theta_true=theta_true,
         grid_ranges=theta_ranges,
@@ -320,7 +323,7 @@ if asymptotic['bool']:
 
 
     # Compute cross sections and effective samples
-    augmenter = SampleAugmenter(config_file, include_nuisance_parameters=False)
+    augmenter = SampleAugmenter(data_file, include_nuisance_parameters=False)
     cross_sec_grid = []
     num_effect_grid = []
     num_sample_test = 10000
@@ -340,7 +343,7 @@ if asymptotic['bool']:
 
     # Compute and save histogram
     for flag in include_xsec:
-        _ , p_values, best_fit_index = limits.expected_limits(
+        _, p_values, best_fit_index, _, _, _ = limits.expected_limits(
             mode="histo",
             theta_true=theta_true,
             grid_ranges=theta_ranges,
@@ -370,15 +373,11 @@ if asymptotic['bool']:
 ###############################
 
 if fisher_info['bool'] and gen_method == 'sally':
-    fisher = FisherInformation(config_file, include_nuisance_parameters=False)
-    theta_true = [
-        float(fisher_info['theta_true'][0]),
-        float(fisher_info['theta_true'][1]),
-        float(fisher_info['theta_true'][2]),
-    ]
+    fisher = FisherInformation(data_file, include_nuisance_parameters=False)
+    fisher_theta = fisher_info['theta_true']
 
     fisher.calculate_fisher_information_full_detector(
-        theta=[0., 0., 0.],
+        theta=fisher_theta,
         model_file=model_dir + '/sally/sally',
         luminosity=30000.
     )
@@ -390,13 +389,11 @@ if fisher_info['bool'] and gen_method == 'sally':
 
 # Generate test data and num_events
 generate_test_data_ratio(gen_method, parameters)
-num_events = calc_num_events(config_file, luminosity)
+num_events = calc_num_events(data_file, luminosity)
 
 # Get Log Likelihood Ratio metrics
-llr_raw = []
-llr_rescaled = []
-thetas = []
-scores = []
+out_llr_raw = []
+out_llr_rescaled = []
 
 theta_grid = np.load(rates_dir + '/grid.npy')
 
@@ -428,26 +425,24 @@ for theta_elem in theta_grid:
     llr_raw = sum(llr[0]) / num_sample_test
     llr_rescaled = num_events * llr_raw
 
-    llr_raw.append(llr_raw)
-    llr_rescaled.append(llr_rescaled)
-    thetas.append(theta_elem)
-    scores.append(score)
+    out_llr_raw.append(llr_raw)
+    out_llr_rescaled.append(llr_rescaled)
 
 
 ################################
 ## Save Log Like. Ratio files ##
 ################################
 
-limits = AsymptoticLimits(config_file)
-llr_sub, _ = limits._subtract_mle(llr_rescaled)
+limits = AsymptoticLimits(data_file)
+llr_sub, _ = limits._subtract_mle(out_llr_rescaled)
 p_values = limits.asymptotic_p_value(llr_sub)
 
 llr_raw_file = results_dir + f'/{gen_method}/llr_raw.npy'
-np.save(file=llr_raw_file, arr=llr_raw)
+np.save(file=llr_raw_file, arr=out_llr_raw)
 print(f'Saved Raw mean -2 log R to file: {llr_raw_file}')
 
 llr_rescaled_file = results_dir + f'/{gen_method}/llr_rescaled.npy'
-np.save(file=llr_rescaled_file, arr=llr_rescaled)
+np.save(file=llr_rescaled_file, arr=out_llr_rescaled)
 print(f'Saved rescaled -2 log R to file: {llr_rescaled_file}')
 
 llr_subtracted_file = results_dir + f'/{gen_method}/llr_subtracted.npy'

--- a/docker-images/docker-madminer-ml/code/plotting.py
+++ b/docker-images/docker-madminer-ml/code/plotting.py
@@ -38,6 +38,7 @@ project_dir = Path(__file__).parent.parent
 
 model_dir = str(project_dir.joinpath('models'))
 plots_dir = str(project_dir.joinpath('plots'))
+rates_dir = str(project_dir.joinpath('rates'))
 results_dir = str(project_dir.joinpath('results'))
 tests_dir = str(project_dir.joinpath('test'))
 
@@ -187,17 +188,17 @@ def do_plot(
         plt.legend()
 
     plt.tight_layout()
-    plt.savefig('/madminer/plots/all_methods_separate.png')
+    plt.savefig(plots_dir + '/all_methods_separate.png')
 
 
 #############################
 ## Load previous rate data ##
 #############################
 
-loaded_grid_data = np.load('/madminer/rates/grid.npy')
-loaded_rate_data = np.load('/madminer/rates/rate.npy')
-loaded_histo_data = np.load('/madminer/rates/histo.npy')
-loaded_histo_kin_data = np.load('/madminer/rates/histo_kin.npy')
+loaded_grid_data = np.load(rates_dir + '/grid.npy', allow_pickle=True)
+loaded_rate_data = np.load(rates_dir + '/rate.npy', allow_pickle=True)
+loaded_histo_data = np.load(rates_dir + '/histo.npy', allow_pickle=True)
+loaded_histo_kin_data = np.load(rates_dir + '/histo_kin.npy', allow_pickle=True)
 
 variables_to_plot = {
     'theta_grid': loaded_grid_data,
@@ -220,11 +221,11 @@ hg_folder_methods = {'sally', 'sallino'}
 for method in methods:
 
     if method in ml_folder_methods:
-        a = np.load(results_dir + f'/{method}/ml/{method}.npy')
-        b = np.load(results_dir + f'/{method}/ml/{method}_kin.npy')
+        a = np.load(results_dir + f'/{method}/ml/{method}.npy', allow_pickle=True)
+        b = np.load(results_dir + f'/{method}/ml/{method}_kin.npy', allow_pickle=True)
     elif method in hg_folder_methods:
-        a = np.load(results_dir + f'/{method}/histo/{method}.npy')
-        b = np.load(results_dir + f'/{method}/histo/{method}_kin.npy')
+        a = np.load(results_dir + f'/{method}/histo/{method}.npy', allow_pickle=True)
+        b = np.load(results_dir + f'/{method}/histo/{method}_kin.npy', allow_pickle=True)
     else:
         raise ValueError('Invalid method')
 
@@ -377,7 +378,7 @@ if plotting['all_methods']:
     c_bar.set_label(f'Expected p-value ({plotting_method.upper()}-Kinematics)')
 
     plt.tight_layout()
-    plt.savefig(plots_dir + '/' + 'all_methods.png')
+    plt.savefig(plots_dir + '/all_methods.png')
 
 
 #############################
@@ -416,9 +417,9 @@ if plotting['correlations']:
 
     for method in inputs['plotting']['correlations_methods']:
 
-        if len(inputs['evaluation'][method]) == 1:
+        if len(inputs[method]) == 1:
             theta_file = 'theta_test.npy'
-        elif len(inputs['evaluation'][method]) == 2:
+        elif len(inputs[method]) == 2:
             theta_file = 'theta0_test.npy'
         else:
             raise ValueError('Invalid number of evaluation methods')

--- a/docker-images/docker-madminer-ml/scripts/1_sampling.sh
+++ b/docker-images/docker-madminer-ml/scripts/1_sampling.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+
+
+# Define help function
+helpFunction()
+{
+    printf "\n"
+    printf "Usage: %s -p project_path -n num_train_samples -i input_file -d data_file\n" "${0}"
+    printf "\t-p Project top-level path\n"
+    printf "\t-n Number of training samples\n"
+    printf "\t-i Workflow input file\n"
+    printf "\t-d Data file path\n"
+    exit 1
+}
+
+# Argument parsing
+while getopts "p:n:i:d:" opt
+do
+    case "$opt" in
+        p ) PROJECT_PATH="$OPTARG" ;;
+        n ) NUM_SAMPLES="$OPTARG" ;;
+        i ) INPUT_FILE="$OPTARG" ;;
+        d ) DATA_FILE="$OPTARG" ;;
+        ? ) helpFunction ;;
+    esac
+done
+
+if [ -z "${PROJECT_PATH}" ] || [ -z "${NUM_SAMPLES}" ] || [ -z "${INPUT_FILE}" ] || [ -z "${DATA_FILE}" ]
+then
+    echo "Some or all of the parameters are empty";
+    helpFunction
+fi
+
+
+# Perform actions
+mkdir -p "${PROJECT_PATH}/data/samples"
+python3 "${PROJECT_PATH}/code/configurate_ml.py" "${NUM_SAMPLES}" "${DATA_FILE}" "${INPUT_FILE}"
+
+# cp -R /madminer/data/Samples_* {sampleworkdir}

--- a/docker-images/docker-madminer-ml/scripts/2_training.sh
+++ b/docker-images/docker-madminer-ml/scripts/2_training.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env sh
+
+
+# Define help function
+helpFunction()
+{
+    printf "\n"
+    printf "Usage: %s -p project_path -i input_file -t train_folder\n" "${0}"
+    printf "\t-p Project top-level path\n"
+    printf "\t-i Workflow input file\n"
+    printf "\t-t Regex selecting the train folders\n"
+    exit 1
+}
+
+# Argument parsing
+while getopts "p:i:t:" opt
+do
+    case "$opt" in
+        p ) PROJECT_PATH="$OPTARG" ;;
+        i ) INPUT_FILE="$OPTARG" ;;
+        t ) TRAIN_FOLDER="$OPTARG" ;;
+        ? ) helpFunction ;;
+    esac
+done
+
+if [ -z "${PROJECT_PATH}" ] || [ -z "${INPUT_FILE}" ] || [ -z "${TRAIN_FOLDER}" ]
+then
+    echo "Some or all of the parameters are empty";
+    helpFunction
+fi
+
+
+# Define auxiliary variables
+MODEL_FILE_ABS_PATH="${PROJECT_PATH}/Model.tar.gz"
+MODEL_INFO_ABS_PATH="${PROJECT_PATH}/models"
+SAMPLES_ABS_PATH="${PROJECT_PATH}/data/${TRAIN_FOLDER}"
+
+
+# Cleanup previous files (useful when run locally)
+rm -rf "${MODEL_FILE_ABS_PATH}"
+rm -rf "${MODEL_INFO_ABS_PATH}"
+
+mkdir -p "${MODEL_INFO_ABS_PATH}"
+
+
+# Perform actions
+python3 "${PROJECT_PATH}/code/train.py" "${SAMPLES_ABS_PATH}" "${INPUT_FILE}"
+tar -czvf "${MODEL_FILE_ABS_PATH}" -C "${MODEL_INFO_ABS_PATH}" .
+
+# cp -R /madminer/Model.tar.gz  {trainworkdir}

--- a/docker-images/docker-madminer-ml/scripts/3_evaluation.sh
+++ b/docker-images/docker-madminer-ml/scripts/3_evaluation.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env sh
+
+
+# Define help function
+helpFunction()
+{
+    printf "\n"
+    printf "Usage: %s -p project_path -i input_file -m model_file -d data_file\n" "${0}"
+    printf "\t-p Project top-level path\n"
+    printf "\t-i Workflow input file\n"
+    printf "\t-m Compressed model path\n"
+    printf "\t-d Data file path\n"
+    exit 1
+}
+
+# Argument parsing
+while getopts "p:i:m:d:" opt
+do
+    case "$opt" in
+        p ) PROJECT_PATH="$OPTARG" ;;
+        i ) INPUT_FILE="$OPTARG" ;;
+        m ) MODEL_FILE="$OPTARG" ;;
+        d ) DATA_FILE="$OPTARG" ;;
+        ? ) helpFunction ;;
+    esac
+done
+
+if [ -z "${PROJECT_PATH}" ] || [ -z "${INPUT_FILE}" ] || [ -z "${MODEL_FILE}" ] || [ -z "${DATA_FILE}" ]
+then
+    echo "Some or all of the parameters are empty";
+    helpFunction
+fi
+
+
+# Define auxiliary variables
+MODELS_ABS_PATH="${PROJECT_PATH}/models"
+RATES_ABS_PATH="${PROJECT_PATH}/rates"
+RESULTS_ABS_PATH="${PROJECT_PATH}/results"
+TESTS_ABS_PATH="${PROJECT_PATH}/test"
+
+
+# Cleanup previous files (useful when run locally)
+rm -rf "${RESULTS_ABS_PATH}"
+rm -rf "${TESTS_ABS_PATH}"
+
+mkdir -p "${MODELS_ABS_PATH}"
+mkdir -p "${RATES_ABS_PATH}"
+mkdir -p "${RESULTS_ABS_PATH}"
+mkdir -p "${TESTS_ABS_PATH}"
+
+
+# Unzip the models folder contents to identify the model
+tar -xvf "${MODEL_FILE}" -C "${MODELS_ABS_PATH}"
+
+MODEL_NAME=$(find "${MODELS_ABS_PATH}" -type d -mindepth 1 -maxdepth 1 -exec basename {} \;)
+MODEL_DIR="${MODELS_ABS_PATH}/${MODEL_NAME}"
+
+
+python3 "${PROJECT_PATH}/code/evaluation.py" "${INPUT_FILE}" "${MODEL_DIR}" "${DATA_FILE}"
+
+tar -czvf "${PROJECT_PATH}/Results_${MODEL_NAME}.tar.gz" \
+    -C "${PROJECT_PATH}" \
+    "models" \
+    "rates" \
+    "results" \
+    "test"
+
+# cp -R /madminer/Results.tar.gz  {evalworkdir}
+# ls -lR

--- a/docker-images/docker-madminer-ml/scripts/4_plotting.sh
+++ b/docker-images/docker-madminer-ml/scripts/4_plotting.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+
+
+# Define help function
+helpFunction()
+{
+    printf "\n"
+    printf "Usage: %s -p project_path -i input_file -r result_files\n" "${0}"
+    printf "\t-p Project top-level path\n"
+    printf "\t-i Workflow input file\n"
+    printf "\t-r Result files paths\n"
+    exit 1
+}
+
+# Argument parsing
+while getopts "p:i:r:" opt
+do
+    case "$opt" in
+        p ) PROJECT_PATH="$OPTARG" ;;
+        i ) INPUT_FILE="$OPTARG" ;;
+        r ) RESULT_FILES="$OPTARG" ;;
+        ? ) helpFunction ;;
+    esac
+done
+
+if [ -z "${PROJECT_PATH}" ] || [ -z "${INPUT_FILE}" ] || [ -z "${RESULT_FILES}" ]
+then
+    echo "Some or all of the parameters are empty";
+    helpFunction
+fi
+
+
+# Perform actions
+mkdir -p "${PROJECT_PATH}/plots"
+
+# POSIX shell scripts do not allow arrays (workaround)
+echo "${RESULT_FILES}" | tr ' ' '\n' | while read file; do
+    echo "${file}"
+    tar -xvf "${file}" -C "${PROJECT_PATH}";
+done
+
+python3 "${PROJECT_PATH}/code/plotting.py" "${INPUT_FILE}"
+
+# ls -lR
+# cp -R /madminer/plots {plotworkdir}

--- a/reana/inputs/input.yml
+++ b/reana/inputs/input.yml
@@ -73,7 +73,6 @@ cuts:
 
 include_nuisance_parameters: False
 methods: ['sally', 'alices', 'alice']
-shuffle: False
 
 # Also used in the 'evaluation' step
 n_samples:

--- a/reana/inputs/input.yml
+++ b/reana/inputs/input.yml
@@ -100,10 +100,6 @@ alices:
         prior_shape: 'gaussian'
         prior_param_0: 0.0
         prior_param_1: 1.0
-      parameter_2:
-        prior_shape: 'gaussian'
-        prior_param_0: 0.0
-        prior_param_1: 1.0
   theta_1:
     sampling_method: 'benchmark'
     argument: 'sm'
@@ -117,10 +113,6 @@ alice:
         prior_param_0: 0.0
         prior_param_1: 1.0
       parameter_1:
-        prior_shape: 'gaussian'
-        prior_param_0: 0.0
-        prior_param_1: 1.0
-      parameter_2:
         prior_shape: 'gaussian'
         prior_param_0: 0.0
         prior_param_1: 1.0
@@ -159,21 +151,6 @@ fisher_information:
   observable: pt_aa
   bins: [30.0,100.0,200.0,400.0]
   histrange: (30.0,400.0)
-
-# Also used in the 'plotting' step
-evaluation:
-  sally:
-    theta:
-      sampling_method: 'benchmark'
-      argument: 'sm'
-  alices:
-    theta:
-      sampling_method: 'morphing_point'
-      argument: [10.0,10.0]
-  alice:
-    theta:
-      sampling_method: 'morphing_point'
-      argument: [10.,010.0]
 
 
 #### STEP: PLOTTING

--- a/reana/workflows/yadage/steps.yml
+++ b/reana/workflows/yadage/steps.yml
@@ -75,13 +75,8 @@ combine:
 sampling:
   environment: *common_env_ml
   process:
-    process_type: interpolated-script-cmd
-    script: |
-      mkdir /madminer/data
-      mkdir /madminer/data/samples
-      python /madminer/code/configurate_ml.py {n_trainsamples} {data_file} {input_file}
-      cd /madminer/data
-      cp -R /madminer/data/Samples_* {sampleworkdir}
+    process_type: string-interpolated-cmd
+    script: scripts/1_sampling.sh -p /madminer -n {num_train_samples} -i {input_file} -d {data_file}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: sampling_file
@@ -90,13 +85,8 @@ sampling:
 training:
   environment: *common_env_ml
   process:
-    process_type: interpolated-script-cmd 
-    script: |
-      mkdir /madminer/models
-      cp -R {trainfolder} /madminer
-      python /madminer/code/train.py /madminer/Samples_*/ {input_file}
-      tar -czvf /madminer/Model.tar.gz /madminer/models
-      cp -R /madminer/Model.tar.gz  {trainworkdir}
+    process_type: string-interpolated-cmd
+    script: scripts/2_training.sh -p /madminer -i {input_file} -t {train_folder}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: trained_file
@@ -105,34 +95,19 @@ training:
 evaluating:
   environment: *common_env_ml
   process:
-    process_type: interpolated-script-cmd
-    script: |
-      mkdir /madminer/models
-      mkdir /madminer/test
-      mkdir /madminer/results
-      mkdir /madminer/rates/
-      tar -xvf {trained_file} -C /madminer/models --strip-components 2
-      python /madminer/code/evaluation.py {input_file} /madminer/models/* {data_file}
-      tar -czvf /madminer/Results.tar.gz /madminer/results /madminer/rates /madminer/test /madminer/models
-      cp -R /madminer/Results.tar.gz  {evalworkdir}
-      ls -lR
+    process_type: string-interpolated-cmd
+    script: scripts/3_evaluation.sh -p /madminer -i {input_file} -m {model_file} -d {data_file}
   publisher:
     publisher_type: interpolated-pub
     publish:
-      results_file: '{evalworkdir}/Results.tar.gz'
+      results_file: 'Results_*.tar.gz'
 
 plotting:
   environment: *common_env_ml
   process:
-    process_type: interpolated-script-cmd
-    script: |
-      mkdir /madminer/plots
-      echo hello
-      for file in {results_file}; do tar -xvf "$file" -C .  --strip-components 1 ; done
-      python /madminer/code/plotting.py {input_file} 
-      ls -lR
-      cp -R /madminer/plots {plotworkdir}
+    process_type: string-interpolated-cmd
+    script: scripts/4_plotting.sh -p /madminer -i {input_file} -r {results_file}
   publisher:
     publisher_type: interpolated-pub
     publish:
-      outputfile: '{outputfile}'
+      outputfile: '{output_file}'

--- a/reana/workflows/yadage/workflow.yml
+++ b/reana/workflows/yadage/workflow.yml
@@ -1,5 +1,10 @@
 stages:
 
+
+  #########################################
+  ######## PHYSICS WORKFLOW STAGES ########
+  #########################################
+
   - name: configurate
     dependencies: [init]
     scheduler:
@@ -55,25 +60,27 @@ stages:
       step: {$ref: 'steps.yml#/combine'}
 
 
+  ########################################
+  ########## ML WORKFLOW STAGES ##########
+  ########################################
+
   - name: sampling
     dependencies: [combine]
     scheduler:
       scheduler_type: singlestep-stage
       parameters:
-        sampleworkdir: '{workdir}'
-        n_trainsamples: {stages: init, output: ntrainsamples}
+        num_train_samples: {stages: init, output: ntrainsamples}
         input_file: {stages: init, output: inputfile, unwrap: true}
         data_file: {stages: combine, output: data_file, unwrap: true}
       step: {$ref: steps.yml#/sampling}
-      
+
   - name: training
     dependencies: [sampling]
     scheduler:
       scheduler_type: multistep-stage
       parameters:
-        trainworkdir: '{workdir}'
         input_file: {stages: init, output: inputfile, unwrap: true}
-        trainfolder: {stages: sampling, output: sampling_file, unwrap: true}
+        train_folder: {stages: sampling, output: sampling_file, unwrap: true}
       scatter:
         method: zip
         parameters: [trainfolder]
@@ -84,11 +91,10 @@ stages:
     scheduler:
       scheduler_type: multistep-stage
       parameters:
-        trained_file: {stages: training, output: trained_file, unwrap: true}
         input_file: {stages: init, output: inputfile, unwrap: true}
+        model_file: {stages: training, output: trained_file, unwrap: true}
         data_file: {stages: combine, output: data_file, unwrap: true}
-        resultsfile: '{workdir}/Results.tar.gz'
-        evalworkdir: '{workdir}'
+        results_file: 'Results.tar.gz'
       scatter:
         method: zip
         parameters: [trained_file]
@@ -99,8 +105,7 @@ stages:
     scheduler:
       scheduler_type: singlestep-stage
       parameters:
-        results_file: {stages: evaluating, output: results_file, unwrap: true}
         input_file: {stages: init, output: inputfile, unwrap: true}
-        plotworkdir: '{workdir}'
-        outputfile: '{workdir}/outputfile.txt'
+        results_file: {stages: evaluating, output: results_file, unwrap: true}
+        output_file: 'outputfile.txt'
       step: {$ref: 'steps.yml#/plotting'}


### PR DESCRIPTION
This PR performs a big refactor on how the shell script commands are run on the [REANA](http://www.reana.io/) workflow. The main goal of the refactor is to **move all the shell script commands from the [steps.yml](https://github.com/scailfin/workflow-madminer/blob/master/reana/workflows/yadage/steps.yml) file into proper `.sh` files**, so that they can be run locally for debugging purposes.

This PR covers the _"ml"_ use-case steps.

---

During the refactor, additional modifications have been performed:

- Update the Docker image to copy the brand new scripts.
- Define a new ML `Makefile` rule: [clean](https://github.com/scailfin/workflow-madminer/compare/master...Sinclert:reana-ml-scripts?expand=1#diff-987d87a6e118901bdd0de523738e981aR9).
- Define a [save_results](https://github.com/scailfin/workflow-madminer/compare/master...Sinclert:reana-ml-scripts?expand=1#diff-b8b18f39d410623c2f22a33b056d2427R288) function within the [evaluation.py](https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-ml/code/evaluation.py) module, in order to simplify saving operations at the end of the module.
- Replace h5py context managers by common Python file opening ([here](https://github.com/scailfin/workflow-madminer/compare/master...Sinclert:reana-ml-scripts?expand=1#diff-a2cabe1afa1eb5ae628467ebe56a69b8R74) and [here](https://github.com/scailfin/workflow-madminer/compare/master...Sinclert:reana-ml-scripts?expand=1#diff-b8b18f39d410623c2f22a33b056d2427R86)). If a context manager is used, data within the `.h5` file is locked the moment the execution flow goes out the context... 🤦 
- Replace [hand-coded Fisher thetas](https://github.com/scailfin/workflow-madminer/compare/master...Sinclert:reana-ml-scripts?expand=1#diff-b8b18f39d410623c2f22a33b056d2427L381) by their arguments version.
- Replace the `evaluate_log_likelihood` function by [evaluate_score](https://github.com/scailfin/workflow-madminer/compare/master...Sinclert:reana-ml-scripts?expand=1#diff-b8b18f39d410623c2f22a33b056d2427R454) when evaluating a `sally` or a `sallino` method. (Following what is specified in the [official tutorial](https://cranmer.github.io/madminer-tutorial/tutorial_particle_physics/3b_score.html#3.-Evaluate-score-estimator)).
- Delete unnecessary `shuffle` option from the [reana/inputs/input.yml](https://github.com/scailfin/workflow-madminer/blob/master/reana/inputs/input.yml) file.
- Delete  [reana/inputs/input.yml](https://github.com/scailfin/workflow-madminer/blob/master/reana/inputs/input.yml) extra parameters causing problems within _"alices"_ and _"alice"_ methods ([here](https://github.com/scailfin/workflow-madminer/compare/master...Sinclert:reana-ml-scripts?expand=1#diff-af1ec4f636d67cc34032ac25a086f9b5L104) and [here](https://github.com/scailfin/workflow-madminer/compare/master...Sinclert:reana-ml-scripts?expand=1#diff-af1ec4f636d67cc34032ac25a086f9b5L124)).
- Delete a _"half-way-done"_ [evaluation](https://github.com/scailfin/workflow-madminer/compare/master...Sinclert:reana-ml-scripts?expand=1#diff-af1ec4f636d67cc34032ac25a086f9b5L164) section within [reana/inputs/input.yml](https://github.com/scailfin/workflow-madminer/blob/master/reana/inputs/input.yml).

---

**New additions:**

- Evaluation results are now differentiated by their method:
    - Discovering their differentiated names, [here](https://github.com/scailfin/workflow-madminer/pull/17/files#diff-d4fb0b8a24e71706fd73e4cba4ca04e7R55).
    - Told REANA that there will be several of them, [here](https://github.com/scailfin/workflow-madminer/pull/17/files#diff-c667b67e2cc44602b4320bc24bf81ce3R103).
    - Iterate over them in the _plot_ step, [here](https://github.com/scailfin/workflow-madminer/pull/17/files#diff-511323484d0d97711c18bec6e2dd9e81R37).