### PR TITLE
Simplify heavy Dockerfile ("-all")

### DIFF
--- a/docker-images/docker-madminer-all/Dockerfile
+++ b/docker-images/docker-madminer-all/Dockerfile
@@ -1,20 +1,69 @@
-### NOTE:
-### This Docker image takes the "heavy-weight" image
-### from the Physics use case as base image
-### and complete it with the Docker commands
-### from the Machine Learning use case
+### IMPORTANT NOTE:
+###
+### This Dockerfile builds the Docker image for the MadMiner "heavy-weight" environment.
+### The "heavy-weight" environment provides a working installation of MadGraph 5
+### and all the necessary sub-dependencies to run Physics-dependent steps:
+### - lhapdf6
+### - pythia8
+### - pythia-pgs
+### - Delphes
+###
+### Please consider, that even if this Dockerfile definition is extremely similar as the one
+### used for the physics steps ("docker-madminer-physics"), it is better not to depend on it,
+### given that the common sections between the two will be moved to a MadMiner provided
+### "heavy" version image soon enough.
+###
+### Check: https://github.com/diana-hep/madminer/issues/421
 
 
 #### Base image
-#### Reference: https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-physics/Dockerfile
-FROM madminertool/docker-madminer-physics:latest
+#### Reference: https://github.com/diana-hep/madminer/blob/master/Dockerfile
+FROM madminertool/docker-madminer:latest
+
+
+#### Install binary dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    wget \
+    ca-certificates \
+    gfortran \
+    build-essential \
+    ghostscript \
+    libboost-all-dev
+
+
+#### Define working folders
+ENV PROJECT_FOLDER "/madminer"
+ENV SOFTWARE_FOLDER "/madminer/software"
+
+
+#### Install MadGraph 5
+WORKDIR ${SOFTWARE_FOLDER}
+
+ENV MG_VERSION "MG5_aMC_v2.6.7"
+ENV MG_FOLDER "MG5_aMC_v2_6_7"
+ENV MG_BINARY "MG5_aMC_v2_6_7/bin/mg5_aMC"
+RUN curl -sSL "https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/${MG_VERSION}.tar.gz" | tar -xzv
+
+# ROOT environment variables
+ENV ROOTSYS /usr/local
+ENV PATH $PATH:$ROOTSYS/bin
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:$ROOTSYS/lib
+ENV DYLD_LIBRARY_PATH $DYLD_LIBRARY_PATH:$ROOTSYS/lib
+
+RUN echo "install lhapdf6" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
+RUN echo "install pythia8" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
+RUN echo "install pythia-pgs" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
+RUN echo "install Delphes" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
+
+# Delphes environment variables
+ENV ROOT_INCLUDE_PATH $ROOT_INCLUDE_PATH:${SOFTWARE_FOLDER}/${MG_FOLDER}/Delphes/external
 
 
 #### Set working directory
-WORKDIR /madminer
+WORKDIR ${PROJECT_FOLDER}
 
 #### Copy files
-COPY code ./code
 COPY requirements-ml.txt requirements-ph.txt ./
 
 

--- a/docker-images/docker-madminer-all/Makefile
+++ b/docker-images/docker-madminer-all/Makefile
@@ -10,14 +10,11 @@ all: build clean copy push
 
 .PHONY: clean
 clean:
-	@rm -rf code
 	@find . -name "requirements-*.txt" -delete
 
 
 .PHONY: copy
 copy:
-	@cp -R ../$(ML_FOLDER)/code/ code/
-	@cp -R ../$(PH_FOLDER)/code/ code/
 	@cp ../$(ML_FOLDER)/requirements.txt requirements-ml.txt
 	@cp ../$(PH_FOLDER)/requirements.txt requirements-ph.txt
 


### PR DESCRIPTION
This small PR aims to simplify the definition of the [MadMiner "heavy" version Docker image](https://github.com/scailfin/workflow-madminer/blob/master/docker-images/docker-madminer-all/Dockerfile), named _docker-madminer-all_.

---

The leitmotiv of these changes is to avoid the inclusion of workflow code into a Docker image, which **only** purpose is to provide an environment, as stated in [this issue response](https://github.com/diana-hep/madminer/issues/421#issuecomment-626647943).

In a sense, the Dockerfile definition returns to a state where it does not depend on the Physics-steps image (named _docker-madminer-physics_), which further amplifies the need of some type of _docker-madminer-heavy_ image being offered by MadMiner repo itself (as proposed throughout [this issue](https://github.com/diana-hep/madminer/issues/421#issue-604080430)).

---

A explanation note regarding this issue has been included into the Dockerfile itself:
> _Please consider, that even if this Dockerfile definition is extremely similar as the one_
> _used for the physics steps ("docker-madminer-physics"), it is better not to depend on it,_
> _given that the common sections between the two will be moved to a MadMiner provided_
> _"heavy" version image soon enough._
>
> _Check: https://github.com/diana-hep/madminer/issues/421_