### PR TITLE
Update REANA yamls

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,37 +55,40 @@ Dependency installation depends on how you want to run the workflow: using a REA
 
 
 ### Deploy with REANA
-To deploy Madminer locally using [REANA][reana-webpage], use _Minikube_ as emulator for a cluster.
-Please refer to the [REANA-Cluster documentation][reana-cluster-docs] for more details.
-If you have access to a REANA cluster, then you will only need to introduce the credentials as shown below,
-to generate the following combined-workflow:
+To deploy Madminer locally using [REANA][reana-webpage], use _VirtualBox_ as emulator and _Minikube_ 
+as container orchestrator in order to simulate a local cluster. Please refer to the **version 0.7.0**
+[new REANA deployment documentation][reana-deploy-docs] for more details.
+
+If you have access to a remote REANA cluster, introduce only the credentials as shown below, to generate 
+the following combined-workflow:
 
 ![image of the workflow](docs/images/workflow-all.png)
 
-To introduce the credentials, go to the `example-full/` directory and run:
+To introduce the credentials, and start the workflow:
 ```bash
-$ virtualenv ~/.virtualenvs/myreana
-$ source ~/.virtualenvs/myreana/bin/activate
-(myreana) $ pip install reana-client==0.5.0
-# enter credentials for REANA-cluster
-(myreana) $ export REANA_ACCESS_TOKEN = [..]
-(myreana) $ export REANA_SERVER_URL = [..]
-# or for minikube deployment
-(myreana) $ eval $(reana-cluster env --include-admin-token)
-# check connectivity to `reana-cluster`
-(myreana) $ reana-client ping
-# create the analysis
-(myreana) $ reana-client create -n my-analysis
-(myreana) $ export REANA_WORKON=my-analysis.1
-(myreana) $ reana-client upload ./inputs/input.yml
-(myreana) $ reana-client start
-(myreana) $ reana-client status
+$ source ~/.virtualenvs/reana/bin/activate
+# A) Enter credentials for a remote-cluster
+(reana) $ export REANA_ACCESS_TOKEN = [..]
+(reana) $ export REANA_SERVER_URL = [..]
+# B) Enter credentials for a minikube local-cluster
+(reana) $ eval $(reana-dev setup-environment)
+# Check connectivity to the cluster
+(reana) $ reana-client ping
+# Create the analysis from within the 'reana' folder
+(reana) $ cd reana
+(reana) $ reana-client create -n madminer-workflow
+(reana) $ export REANA_WORKON=madminer-workflow
+(reana) $ reana-client upload ./inputs/input.yml
+(reana) $ reana-client upload ./workflows/yadage/workflow.yml
+(reana) $ reana-client upload ./workflows/yadage/steps.yml
+(reana) $ reana-client start
+(reana) $ reana-client status
 ```
 
 It might take some time to finish depending on the job and the cluster. Once it does, list and download the files:
 ```bash
-(myreana) $ reana-client ls
-(myreana) $ reana-client download <path/to/file/on/reana/workon>
+(reana) $ reana-client ls
+(reana) $ reana-client download <path/to/file/on/reana/workon>
 ```
 
 The command `reana-client ls` will display the folders containing the results from each step.
@@ -219,7 +222,7 @@ Without taking into account the inputs and the map-reduce, the general workflow 
 [madminer-docs]: https://madminer.readthedocs.io/en/latest/index.html
 [madminer-repo]: https://github.com/diana-hep/madminer
 [madminer-tutorial]: https://github.com/diana-hep/madminer/tree/master/examples/tutorial_particle_physics
-[reana-cluster-docs]: https://reana-cluster.readthedocs.io/en/latest/gettingstarted.html
+[reana-deploy-docs]: http://docs.reana.io/development/deploying-locally/
 [reana-webpage]: http://www.reanahub.io/
 [travis-build-status]: https://travis-ci.com/irinaespejo/workflow-madminer.svg?branch=master
 [yadage-docs]: https://yadage.readthedocs.io/en/latest/

--- a/docker-images/docker-madminer-all/Dockerfile
+++ b/docker-images/docker-madminer-all/Dockerfile
@@ -68,10 +68,10 @@ COPY requirements-ml.txt requirements-ph.txt ./
 
 
 # Install Python2 dependencies
-RUN pip install --upgrade pip && \
-    pip install --no-cache-dir --requirement requirements-ml.txt && \
-    pip install --no-cache-dir --requirement requirements-ph.txt
+RUN python2 -m pip install --upgrade pip && \
+    python2 -m pip install --no-cache-dir --requirement requirements-ml.txt && \
+    python2 -m pip install --no-cache-dir --requirement requirements-ph.txt
 
 # Install Python3 dependencies
-RUN pip3 install --upgrade pip && \
-    pip3 install --no-cache-dir --requirement requirements-ml.txt
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install --no-cache-dir --requirement requirements-ml.txt

--- a/docker-images/docker-madminer-ml/Dockerfile
+++ b/docker-images/docker-madminer-ml/Dockerfile
@@ -13,9 +13,9 @@ COPY requirements.txt .
 
 
 # Install Python2 dependencies
-RUN pip install --upgrade pip && \
-    pip install --no-cache-dir --requirement requirements.txt
+RUN python2 -m pip install --upgrade pip && \
+    python2 -m pip install --no-cache-dir --requirement requirements.txt
 
 # Install Python3 dependencies
-RUN pip3 install --upgrade pip && \
-    pip3 install --no-cache-dir --requirement requirements.txt
+RUN python3 -m pip install --upgrade pip && \
+    python3 -m pip install --no-cache-dir --requirement requirements.txt

--- a/docker-images/docker-madminer-physics/Dockerfile
+++ b/docker-images/docker-madminer-physics/Dockerfile
@@ -52,5 +52,5 @@ COPY requirements.txt .
 
 
 # Install Python2 dependencies
-RUN pip install --upgrade pip && \
-    pip install --no-cache-dir --requirement requirements.txt
+RUN python2 -m pip install --upgrade pip && \
+    python2 -m pip install --no-cache-dir --requirement requirements.txt

--- a/reana/workflows/yadage/steps.yml
+++ b/reana/workflows/yadage/steps.yml
@@ -21,7 +21,7 @@ configurate:
   environment: *common_env_physics
   process:
     process_type: string-interpolated-cmd
-    script: scripts/1_configurate.sh -p /madminer -i {input_file}
+    cmd: scripts/1_configurate.sh -p /madminer -i {input_file}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: config_file
@@ -31,7 +31,7 @@ generate:
   environment: *common_env_physics
   process:
     process_type: string-interpolated-cmd
-    script: scripts/2_generate.sh -p /madminer -s {signal_dir} -j {num_jobs} -c {config_file}
+    cmd: scripts/2_generate.sh -p /madminer -s {signal_dir} -j {num_jobs} -c {config_file}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: script_files
@@ -41,7 +41,7 @@ mg_pythia:
   environment: *common_env_physics
   process:
     process_type: string-interpolated-cmd
-    script: scripts/3_pythia.sh -p /madminer -m {madgraph_dir} -s {signal_dir} -l {logs_dir} -z {events_folder}
+    cmd: scripts/3_pythia.sh -p /madminer -m {madgraph_dir} -s {signal_dir} -l {logs_dir} -z {events_folder}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: postrun_file
@@ -51,7 +51,7 @@ delphes:
   environment: *common_env_physics
   process:
     process_type: string-interpolated-cmd
-    script: scripts/4_delphes.sh -p /madminer -c {config_file} -i {input_file} -e {event_file}
+    cmd: scripts/4_delphes.sh -p /madminer -c {config_file} -i {input_file} -e {event_file}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: dpostrun_file
@@ -61,7 +61,7 @@ combine:
   environment: *common_env_physics
   process:
     process_type: string-interpolated-cmd
-    script: scripts/5_combine.sh -p /madminer -i {input_files}
+    cmd: scripts/5_combine.sh -p /madminer -i {input_files}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: data_file
@@ -76,7 +76,7 @@ sampling:
   environment: *common_env_ml
   process:
     process_type: string-interpolated-cmd
-    script: scripts/1_sampling.sh -p /madminer -n {num_train_samples} -i {input_file} -d {data_file}
+    cmd: scripts/1_sampling.sh -p /madminer -n {num_train_samples} -i {input_file} -d {data_file}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: sampling_file
@@ -86,7 +86,7 @@ training:
   environment: *common_env_ml
   process:
     process_type: string-interpolated-cmd
-    script: scripts/2_training.sh -p /madminer -i {input_file} -t {train_folder}
+    cmd: scripts/2_training.sh -p /madminer -i {input_file} -t {train_folder}
   publisher:
     publisher_type: 'fromglob-pub'
     outputkey: trained_file
@@ -96,7 +96,7 @@ evaluating:
   environment: *common_env_ml
   process:
     process_type: string-interpolated-cmd
-    script: scripts/3_evaluation.sh -p /madminer -i {input_file} -m {model_file} -d {data_file}
+    cmd: scripts/3_evaluation.sh -p /madminer -i {input_file} -m {model_file} -d {data_file}
   publisher:
     publisher_type: interpolated-pub
     publish:
@@ -106,7 +106,7 @@ plotting:
   environment: *common_env_ml
   process:
     process_type: string-interpolated-cmd
-    script: scripts/4_plotting.sh -p /madminer -i {input_file} -r {results_file}
+    cmd: scripts/4_plotting.sh -p /madminer -i {input_file} -r {results_file}
   publisher:
     publisher_type: interpolated-pub
     publish:

--- a/reana/workflows/yadage/steps.yml
+++ b/reana/workflows/yadage/steps.yml
@@ -5,12 +5,12 @@
 common_env_physics: &common_env_physics
     environment_type: 'docker-encapsulated'
     image: madminertool/docker-madminer-physics
-    imagetag: 'latest'
+    imagetag: '0.1.0'
 
 common_env_ml: &common_env_ml
     environment_type: 'docker-encapsulated'
     image: madminertool/docker-madminer-ml
-    imagetag: 'latest'
+    imagetag: '0.1.0'
 
 
 ########################################

--- a/reana/workflows/yadage/workflow.yml
+++ b/reana/workflows/yadage/workflow.yml
@@ -10,43 +10,43 @@ stages:
     scheduler:
       scheduler_type: singlestep-stage
       parameters:
-        input_file: {stages: init, output: inputfile, unwrap: true}
-      step: {$ref: 'steps.yml#/configurate'}
+        input_file: {step: init, output: inputfile}
+      step: {$ref: 'workflows/yadage/steps.yml#/configurate'}
 
   - name: generate
     dependencies: [configurate]
     scheduler:
       scheduler_type: singlestep-stage
       parameters:
-        input_file: {stages: init, output: inputfile, unwrap: true}
-        config_file: {stages: configurate, output: config_file, unwrap: true}
-        num_jobs: {stages: init, output: njobs}
+        input_file: {step: init, output: inputfile}
+        config_file: {step: configurate, output: config_file}
+        num_jobs: {step: init, output: njobs}
         signal_dir: 'code/mg_processes/signal'
-      step: {$ref: 'steps.yml#/generate'}
+      step: {$ref: 'workflows/yadage/steps.yml#/generate'}
 
   - name: mgpythia
     dependencies: [generate]
     scheduler:
       scheduler_type: multistep-stage
       parameters:
-        events_folder: {stages: generate, output: script_files, unwrap: true}
+        events_folder: {step: generate, output: script_files}
         madgraph_dir: 'software/MG5_aMC_v2_6_7'
         signal_dir: 'code/mg_processes/signal'
         logs_dir: 'code/logs'
       scatter:
         method: zip
         parameters: [eventfolder]
-      step: {$ref: 'steps.yml#/mg_pythia'}
+      step: {$ref: 'workflows/yadage/steps.yml#/mg_pythia'}
 
   - name: delphes
     dependencies: [mgpythia]
     scheduler:
       scheduler_type: multistep-stage
       parameters:
-        config_file: {stages: configurate, output: config_file, unwrap: true}
-        input_file: {stages: init, output: inputfile, unwrap: true}
-        event_file: {stages: mgpythia, output: postrun_file, unwrap: true}
-      step: {$ref: 'steps.yml#/delphes'}
+        config_file: {step: configurate, output: config_file}
+        input_file: {step: init, output: inputfile}
+        event_file: {step: mgpythia, output: postrun_file}
+      step: {$ref: 'workflows/yadage/steps.yml#/delphes'}
       scatter:
         method: zip
         parameters: [eventfile]
@@ -56,8 +56,8 @@ stages:
     scheduler:
       scheduler_type: singlestep-stage
       parameters:
-        input_files: {stages: delphes, output: dpostrun_file}
-      step: {$ref: 'steps.yml#/combine'}
+        input_files: {step: delphes, output: dpostrun_file}
+      step: {$ref: 'workflows/yadage/steps.yml#/combine'}
 
 
   ########################################
@@ -69,43 +69,43 @@ stages:
     scheduler:
       scheduler_type: singlestep-stage
       parameters:
-        num_train_samples: {stages: init, output: ntrainsamples}
-        input_file: {stages: init, output: inputfile, unwrap: true}
-        data_file: {stages: combine, output: data_file, unwrap: true}
-      step: {$ref: steps.yml#/sampling}
+        num_train_samples: {step: init, output: ntrainsamples}
+        input_file: {step: init, output: inputfile}
+        data_file: {step: combine, output: data_file}
+      step: {$ref: 'workflows/yadage/steps.yml#/sampling'}
 
   - name: training
     dependencies: [sampling]
     scheduler:
       scheduler_type: multistep-stage
       parameters:
-        input_file: {stages: init, output: inputfile, unwrap: true}
-        train_folder: {stages: sampling, output: sampling_file, unwrap: true}
+        input_file: {step: init, output: inputfile}
+        train_folder: {step: sampling, output: sampling_file}
       scatter:
         method: zip
         parameters: [trainfolder]
-      step: {$ref: 'steps.yml#/training'}
+      step: {$ref: 'workflows/yadage/steps.yml#/training'}
 
   - name: evaluating
     dependencies: [training]
     scheduler:
       scheduler_type: multistep-stage
       parameters:
-        input_file: {stages: init, output: inputfile, unwrap: true}
-        model_file: {stages: training, output: trained_file, unwrap: true}
-        data_file: {stages: combine, output: data_file, unwrap: true}
+        input_file: {step: init, output: inputfile}
+        model_file: {step: training, output: trained_file}
+        data_file: {step: combine, output: data_file}
         results_file: 'Results.tar.gz'
       scatter:
         method: zip
         parameters: [trained_file]
-      step: {$ref: 'steps.yml#/evaluating'}
+      step: {$ref: 'workflows/yadage/steps.yml#/evaluating'}
 
   - name: plotting
     dependencies: [evaluating]
     scheduler:
       scheduler_type: singlestep-stage
       parameters:
-        input_file: {stages: init, output: inputfile, unwrap: true}
-        results_file: {stages: evaluating, output: results_file, unwrap: true}
+        input_file: {step: init, output: inputfile}
+        results_file: {step: evaluating, output: results_file}
         output_file: 'outputfile.txt'
-      step: {$ref: 'steps.yml#/plotting'}
+      step: {$ref: 'workflows/yadage/steps.yml#/plotting'}


### PR DESCRIPTION
This PR updates the [reana folder](https://github.com/scailfin/workflow-madminer/tree/master/reana) manifests to be compatible with the latest version of REANA (version `0.7.0-dev` for now).

In order to make them usage, several fixes were carried out:
- Correctly install packages on multi-python environments (`python2 -m pip` VS`pip`).
- Correctly reference [steps.yml](https://github.com/scailfin/workflow-madminer/blob/master/reana/workflows/yadage/steps.yml) from within the [workflow.yml](https://github.com/scailfin/workflow-madminer/blob/master/reana/workflows/yadage/workflow.yml) manifest.
- Fix invalid `script` entry when defining steps (replaced by `cmd`).

In addition, some optimizations:
- The README was updated to reflect interactions with the latest state of REANA (_spoiler alert_: from `v0.7.0` the `reana-cluster` module will be deprecated in favor of [Helm](https://helm.sh/), directly controlled from the [reanahub/reana Makefile](https://github.com/reanahub/reana/blob/master/Makefile)).
- Steps input definition was simplified following what I saw on [this REANA demo commit](https://github.com/reanahub/reana-demo-helloworld/commit/6119ae2eab42d5af3ca2f129572bc8415de761aa).
- Workflow docker images were locked to version `0.1.0` to avoid surprises when pushing newer images.
