### PR TITLE
Physics Docker cleanup

### DIFF
--- a/docker-images/docker-madminer-all/Dockerfile
+++ b/docker-images/docker-madminer-all/Dockerfile
@@ -25,6 +25,7 @@ FROM madminertool/docker-madminer:latest
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     wget \
+    rsync \
     ca-certificates \
     gfortran \
     build-essential \

--- a/docker-images/docker-madminer-all/Dockerfile
+++ b/docker-images/docker-madminer-all/Dockerfile
@@ -5,7 +5,6 @@
 ### and all the necessary sub-dependencies to run Physics-dependent steps:
 ### - lhapdf6
 ### - pythia8
-### - pythia-pgs
 ### - Delphes
 ###
 ### Please consider, that even if this Dockerfile definition is extremely similar as the one
@@ -54,7 +53,6 @@ ENV DYLD_LIBRARY_PATH $DYLD_LIBRARY_PATH:$ROOTSYS/lib
 
 RUN echo "install lhapdf6" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
 RUN echo "install pythia8" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
-RUN echo "install pythia-pgs" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
 RUN echo "install Delphes" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
 
 # Delphes environment variables

--- a/docker-images/docker-madminer-physics/Dockerfile
+++ b/docker-images/docker-madminer-physics/Dockerfile
@@ -36,7 +36,6 @@ ENV DYLD_LIBRARY_PATH $DYLD_LIBRARY_PATH:$ROOTSYS/lib
 
 RUN echo "install lhapdf6" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
 RUN echo "install pythia8" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
-RUN echo "install pythia-pgs" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
 RUN echo "install Delphes" | python2 ${SOFTWARE_FOLDER}/${MG_BINARY}
 
 # Delphes environment variables

--- a/docker-images/docker-madminer-physics/Dockerfile
+++ b/docker-images/docker-madminer-physics/Dockerfile
@@ -7,6 +7,7 @@ FROM madminertool/docker-madminer:latest
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     wget \
+    rsync \
     ca-certificates \
     gfortran \
     build-essential \


### PR DESCRIPTION
This PR both:
- Fixes an issue raised from the update of _"upstream"_ Docker images to Ubuntu 20.04.
- Simplifies the installation of MadGraph5 dependencies getting rid of `pythia-pgs`.

---

### Context
After bumping up the official ROOT Ubuntu Docker image to Ubuntu 20.04 (https://github.com/root-project/root-docker/pull/11), and updating MadMiner official Docker image to use that one as its base (https://github.com/diana-hep/madminer/pull/427 and https://github.com/diana-hep/madminer/pull/428), I realized Ubuntu 20.04 does not have the `rsync` package installed by default.

In addition, when building the `docker-madminer-physics` image, I noticed the installation of `pythia-pgs` fails. This is strange because I considered it to be a mandatory requirement to work with this workflow, and yet the workflow is  executable without its presence...

I think it may have been useful in the past, but it seems that is not the case any more.

---

### References:

Regarding `pythia-pgs` installation failure, I found these references:

- https://bugs.launchpad.net/pythia-pgs-for-mg/+bug/1782113
- https://answers.launchpad.net/mg5amcnlo/+question/677417


